### PR TITLE
Change the type of Input.Key to a map[string]interface{}

### DIFF
--- a/consul-template-mock.go
+++ b/consul-template-mock.go
@@ -17,7 +17,7 @@ type Secret struct {
 
 type Input struct {
 	Service map[string]interface{}
-	Key     map[string]string
+	Key     map[string]interface{}
 	Env     map[string]string
 	File    map[string]string
 	Secret  map[string]map[string]interface{}
@@ -63,13 +63,13 @@ func mock(templateText, mockData []byte, wr io.Writer) error {
 			}
 			return "", fmt.Errorf("file '%s' doesn't exist: %s", fileName, err)
 		},
-		"key": func(key string) (string, error) {
+		"key": func(key string) (interface{}, error) {
 			if i, ok := input.Key[key]; ok {
 				return i, nil
 			}
 			return "", fmt.Errorf("key '%s' doesn't exist: %s", key, err)
 		},
-		"keyOrDefault": func(key, def string) string {
+		"keyOrDefault": func(key, def string) interface{} {
 			if i, ok := input.Key[key]; ok {
 				return i
 			}

--- a/examples/simple.json
+++ b/examples/simple.json
@@ -1,7 +1,8 @@
 { "service": {
     "a_service": [{"Name":"with_its_name"}]},
   "key": {
-      "a_key": "with_its_value"
+      "a_key": "with_its_value",
+      "a_dict": {"foo": "bar"}
   },
   "env": {"a_environment_variable": "with_its_value"},
   "secret": {"a_secret_path": {

--- a/examples/simple.rendered
+++ b/examples/simple.rendered
@@ -14,4 +14,7 @@ env: with_its_value
 
 keyOrDefault: default
 
-key: with_its_value
+key:
+  a_key: with_its_value
+  a_dict:
+    foo: bar

--- a/examples/simple.tmpl
+++ b/examples/simple.tmpl
@@ -19,4 +19,9 @@ env: {{  env "a_environment_variable" }}
 
 keyOrDefault: {{ keyOrDefault "simple-not-existing" "default" }}
 
-key: {{ key "a_key" }}
+key:
+  a_key: {{ key "a_key" }}
+  a_dict:
+  {{- range $i, $v := key "a_dict"}}
+    {{ $i }}: {{ $v }}
+  {{- end}}


### PR DESCRIPTION
Consul keys can contain any json structure; it does not have to be a string.