### PR TITLE
feat: do not fail on missing keys

### DIFF
--- a/consul-template-mock.go
+++ b/consul-template-mock.go
@@ -133,7 +133,7 @@ func mock(templateText, mockData []byte, wr io.Writer) error {
         },	
     }
 
-	tmpl, err := template.New("template").Funcs(funcMap).Option("missingkey=error").Parse(string(templateText))
+	tmpl, err := template.New("template").Funcs(funcMap).Option("missingkey=default").Parse(string(templateText))
 	if err != nil {
 		return fmt.Errorf("parsing template: %s", err)
 	}

--- a/consul-template-mock_test.go
+++ b/consul-template-mock_test.go
@@ -37,6 +37,8 @@ func TestMissing(t *testing.T) {
 	mockData := []byte("{ \"secret\": {\"a\": {\"b\": \"c\"}}}")
 
 	if err := mock(template, mockData, rw); err == nil {
-		t.Errorf("Keys of map must be present")
+        if rw.String() != "<no value>" {
+            t.Errorf("Keys of map must be present")
+        }
 	}
 }

--- a/examples/simple.rendered
+++ b/examples/simple.rendered
@@ -5,6 +5,8 @@ secret:
   a_list_of_secrets:
     - 1111
     - 2222
+  missing_key: <no value>
+  missing_key2: missing
 
 regexReplaceAll: simple
 

--- a/examples/simple.tmpl
+++ b/examples/simple.tmpl
@@ -9,6 +9,12 @@ secret:
     {{- range $index, $data := .Data.a_list_of_secrets }}
     - {{ $data }}
     {{- end }}
+  missing_key: {{ .Data.missing_key }}
+  {{- if .Data.missing_key2 }}
+  missing_key2: {{ .Data.missing_key2 }}
+  {{- else }}
+  missing_key2: missing
+  {{- end -}}
 {{- end }}
 
 regexReplaceAll: {{ "simple" | regexReplaceAll "http://(.*)ple" "$1" }}


### PR DESCRIPTION
Hello @nlewo 
Please consider another PR

### Motivation

1. `consul-template` does not fail when keys are missing, for instance, from secret. So, this tool should not fail as well.

1. It's a common pattern to conditionally render parts of template only when keys are present. Like [in docs](https://github.com/hashicorp/consul-template#secret)
![image](https://user-images.githubusercontent.com/1279477/96890152-0bc15d80-1490-11eb-9d9a-ba8b069ad8f5.png)

Currently it was impossible, and this PR allows to render such templates exactly like `consul-template` does.